### PR TITLE
Re-align the guide section

### DIFF
--- a/.vs/ProjectSettings.json
+++ b/.vs/ProjectSettings.json
@@ -1,0 +1,3 @@
+{
+  "CurrentProjectSetting": null
+}

--- a/scripts/guides.cjs
+++ b/scripts/guides.cjs
@@ -114,7 +114,7 @@ sidebar:
 
 import { LinkCard, CardGrid } from "@astrojs/starlight/components";
 
-<CardGrid stagger>
+<CardGrid>
   ${linkCards.join('\n  ')}
 </CardGrid>
 `;

--- a/src/content/docs/guides/index.mdx
+++ b/src/content/docs/guides/index.mdx
@@ -6,7 +6,7 @@ sidebar:
 
 import { LinkCard, CardGrid } from "@astrojs/starlight/components";
 
-<CardGrid stagger>
+<CardGrid>
   <LinkCard
               title="Animations Guides"
               description="Examples & Guides"

--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -33,7 +33,7 @@ bash <(curl -s https://raw.githubusercontent.com/splashkit/skm/master/install-sc
 
 ## Features
 
-<CardGrid stagger>
+<CardGrid>
   <Card title="Easy Integration" icon="pencil">
     SplashKit SDK offers seamless integration with your existing development
     environment, making it easy to incorporate powerful graphics and game

--- a/src/content/docs/installation/index.mdx
+++ b/src/content/docs/installation/index.mdx
@@ -10,7 +10,7 @@ import { Card, LinkCard, CardGrid } from "@astrojs/starlight/components";
 import { ScriptComp } from '../../../assets/ScriptComp'
 
 
-<CardGrid stagger>
+<CardGrid>
   <Card title="Windows" icon="pencil">
     SplashKit SDK offers seamless integration with your existing development
     environment, making it easy to incorporate powerful graphics and game


### PR DESCRIPTION
This Re-aligns the guide section and all sections with a staggered grid layout. Attempts to change the icons were made and I spent many hours trying to learn how to add custom icons that would fit in these cards. The current framework seems almost hostile to making custom icon changes, so this would involve making changes to the components themselves and is a much larger task than anticipated. Very strong possibility to continue this as a separate card in the future.