### PR TITLE
Dead/ wrong redirecting links fixed

### DIFF
--- a/src/content/docs/guides/05-00-camera.mdx
+++ b/src/content/docs/guides/05-00-camera.mdx
@@ -32,9 +32,9 @@ With the camera you can create the effect of moving past stationary background o
 - [Set Camera X](/api/camera/#set-camera-x) - adjust the x value for the camera
 - [Set Camera Y](/api/camera/#set-camera-y) - adjust the y value for the camera
 - [Set Camera Position](/api/camera/#set-camera-position) - adjust the camera position
-- [Move Camera By](/api/camera/#group-move-camera-by) - move the camera a specified amount
-- [Move Camera To](/api/camera/#group-move-camera-to) - move the camera to a location
-- [Center Camera On](/api/camera/#group-center-camera-on) - position the camera to focus on a sprite
+- [Move Camera By](/api/camera/#move-camera-by) - move the camera a specified amount
+- [Move Camera To](/api/camera/#move-camera-to) - move the camera to a location
+- [Center Camera On](/api/camera/#center-camera-on) - position the camera to focus on a sprite
 
 ## Where is the mouse?
 
@@ -42,7 +42,7 @@ Once you use the camera, then you need to map any interactions with the screen f
 
 You can translate between these coordinate systems using the [To Screen](/api/camera/#group-to-screen) and [To World](/api/camera/#to-world).
 
-- [To Screen](/api/camera/#group-to-screen) converts values from world coordinates to screen coordinates.
+- [To Screen](/api/camera/#to-screen) converts values from world coordinates to screen coordinates.
 - [To World](/api/camera/#to-world) converts a screen coordinate to a game world coordinate.
 - [To World X](/api/camera/#to-world-x) converts a screen x value to its location in the game world.
 - [To World Y](/api/camera/#to-world-y) converts a screen y value to its location in the game world.
@@ -53,8 +53,8 @@ You can translate between these coordinate systems using the [To Screen](/api/ca
 
 Some game elements will need to remain in the same place, regardless of the camera position. To achieve this you need to use the [Option To Screen](/api/graphics/#group-option-to-screen). Drawing options allow you to customise each of the drawing instructions. Each drawing operation include a variation that accepts a Drawing Option value.
 
-- [Option To Screen](/api/graphics/#group-option-to-screen) ignore camera position when drawing
-- [Option To World](/api/graphics/#group-option-to-world) adjust all positions based on the camera position
+- [Option To Screen](/api/graphics/#option-to-screen) ignore camera position when drawing
+- [Option To World](/api/graphics/#option-to-world) adjust all positions based on the camera position
 
 ## Example Code
 

--- a/src/content/docs/guides/06-00-bundles.mdx
+++ b/src/content/docs/guides/06-00-bundles.mdx
@@ -26,7 +26,7 @@ Following the resource kind is the resources name and the associated filename fo
 
 Bitmap and font resources also require additional information.
 
-**BITMAP** can optionally be followed by bitmap cell details useful for animation [Using Animations](/guides/animations/using-animation/). This is in the format: `BITMAP, name, filename, width, height, cellCols, cellRows, cellCount`. Once the bitmap is loaded the bundle will set the cell details from the information given.
+**BITMAP** can optionally be followed by bitmap cell details useful for animation [Using Animations](../03-00-animation). This is in the format: `BITMAP, name, filename, width, height, cellCols, cellRows, cellCount`. Once the bitmap is loaded the bundle will set the cell details from the information given.
 
 **FONT** must be followed by the point size for the font.
 

--- a/src/content/docs/guides/09-00-servers.mdx
+++ b/src/content/docs/guides/09-00-servers.mdx
@@ -17,7 +17,7 @@ Web browsers and servers are programs that make it possible for you to access re
 
 For the computer you connected with to know what to do there must be a program that is listening for these requests and performing some actions in response. In this case that program is what we generally call a "web server". It has an open port (somewhere for others to connect to) and listens on that port for incoming connections. When the connection arrives, it can read the request, perform some actions, and respond.
 
-In this article you will see how to start listening for connections, how to send a file in response, and how to stop listening for new connections. This is then build upon in the [routing with servers](/guides/networking/routing-with-servers/) article, which shows you how to customise your response based upon what the caller requested.
+In this article you will see how to start listening for connections, how to send a file in response, and how to stop listening for new connections. This is then build upon in the [routing with servers](../09-01-routing-with-servers) article, which shows you how to customise your response based upon what the caller requested.
 
 ## Step 1: Getting Started
 
@@ -40,9 +40,9 @@ Save it as "index.html" in **Resources/server** and we are ready to start!
 
 ## Step 2: Starting The Server
 
-To start listening for incoming connections, you need to call the [Start Web Server](/api/networking/#group-start-web-server) procedure. You can pass a **port** value (integer) to this to indicate which port to listen for connections. Each computer can support multiple concurrent connections, so each needs a unique address, so there can only be one program using a given port at one time. To help make this easier to navigate, there are standards for which port to use, and in general, web servers listen on port 80 for insecure (http) traffic, and port 443 for secure (https) traffic, while secure shell (ssh; remote terminal access) is port 22, for example. For local web servers, it’s standard to use port 8080.
+To start listening for incoming connections, you need to call the [Start Web Server](/api/networking/#start-web-server) procedure. You can pass a **port** value (integer) to this to indicate which port to listen for connections. Each computer can support multiple concurrent connections, so each needs a unique address, so there can only be one program using a given port at one time. To help make this easier to navigate, there are standards for which port to use, and in general, web servers listen on port 80 for insecure (http) traffic, and port 443 for secure (https) traffic, while secure shell (ssh; remote terminal access) is port 22, for example. For local web servers, it’s standard to use port 8080.
 
-We need to pair the [Start Web Server](/api/networking/#group-start-web-server) with a call to the [Stop Web Server](/api/networking/#stop-web-server) procedure. This will wrap up any requests that have come in and will stop listening for any new requests. So once you are finished with the web server, you can stop it so that it does not take up system resources that you do not need. The following code shows a small program that starts and stops a web server.
+We need to pair the [Start Web Server](/api/networking/#start-web-server) with a call to the [Stop Web Server](/api/networking/#stop-web-server) procedure. This will wrap up any requests that have come in and will stop listening for any new requests. So once you are finished with the web server, you can stop it so that it does not take up system resources that you do not need. The following code shows a small program that starts and stops a web server.
 
 <Tabs>
   <TabItem label="C++">
@@ -126,9 +126,9 @@ class Program
 
 ## Step 3: Responding to a request
 
-[Start Web Server](/api/networking/#group-start-web-server) will get the computer to listen for incoming connections on port 8080. So now we need to tell it what to do when a request comes in. Each request needs to have a response, and the client's web browser will be waiting for this.
+[Start Web Server](/api/networking/#start-web-server) will get the computer to listen for incoming connections on port 8080. So now we need to tell it what to do when a request comes in. Each request needs to have a response, and the client's web browser will be waiting for this.
 
-To send a response, you can use the [Send Response](/api/networking/#group-send-response) procedure. There are several different versions of this, but the easiest allows you to send a string back as a response to the request. In order to send a response, we must wait to get the next incoming request. This is done by calling the [Next Web Request](/api/networking/#next-web-request) function. When you call this, the computer will wait for a request to come in to the web server, and when it arrives, the details are packaged up for us to use and sent back as an [HTTP Request](/api/networking/#http-request). If you don't want to wait, you can check if there are requests before calling [Next Web Request](/api/networking/#next-web-request) by using the [Has Incoming Requests](/api/networking/#has-incoming-requests) function, which will return true if there is a request waiting.
+To send a response, you can use the [Send Response](/api/networking/#send-response) procedure. There are several different versions of this, but the easiest allows you to send a string back as a response to the request. In order to send a response, we must wait to get the next incoming request. This is done by calling the [Next Web Request](/api/networking/#next-web-request) function. When you call this, the computer will wait for a request to come in to the web server, and when it arrives, the details are packaged up for us to use and sent back as an [HTTP Request](/api/networking/#http-request). If you don't want to wait, you can check if there are requests before calling [Next Web Request](/api/networking/#next-web-request) by using the [Has Incoming Requests](/api/networking/#has-incoming-requests) function, which will return true if there is a request waiting.
 
 The following code shows an appropriate `"Hello World"` web server program.
 

--- a/src/content/docs/guides/09-01-routing-with-servers.mdx
+++ b/src/content/docs/guides/09-01-routing-with-servers.mdx
@@ -11,7 +11,7 @@ import { Tabs, TabItem } from "@astrojs/starlight/components";
 **{frontmatter.description}**
 _Written by {frontmatter.author} on {frontmatter.lastupdated}_
 
-This article extends the skills gained from [getting started with servers](/guides/networking/getting-started-with-servers/) specifically around serving different files for different paths
+This article extends the skills gained from [getting started with servers](../09-00-servers) specifically around serving different files for different paths
 
 ##Routing
 Routing is an important part of the web server's job. This is how you get different pages depending on your requests for login, home, or about, pages on a site. Basically, a URL is structured **[serverName]:[port]/[route]**, for example **localhost:8080/login**

--- a/src/content/docs/installation/Linux/index.mdx
+++ b/src/content/docs/installation/Linux/index.mdx
@@ -13,22 +13,22 @@ import { LinkCard, CardGrid } from "@astrojs/starlight/components";
   <LinkCard
     title="Installing the SplashKit Manager"
     description="Step 1"
-    href="/installation/macos/step-1/"
+    href="/installation/linux/step-1/"
   />
   <LinkCard
     title="Make the SplashKit source"
     description="Step 2"
-    href="/installation/macos/step-2/"
+    href="/installation/linux/step-2/"
   />
   <LinkCard
     title="Install Visual Studio Code"
     description="Step 3"
-    href="/installation/macos/step-3/"
+    href="/installation/linux/step-3/"
   />
   <LinkCard
     title="Install Language Specific Tools"
     description="Step 4"
-    href="/installation/macos/step-3/"
+    href="/installation/linux/step-4/"
   />
 </CardGrid>
 

--- a/src/content/docs/troubleshoot/windows/List/win-issue-2.md
+++ b/src/content/docs/troubleshoot/windows/List/win-issue-2.md
@@ -21,7 +21,7 @@ description: A reference page in my new Starlight docs site.
 terminal) and create the project files in its own directory/folder.
 1. **Solution 4:**
     Add the folder containing splashkit.dll file to your path environment variable manually.
-    Firstly, go through Steps 1 – 3 shown in the “Update your system “Path” variable” section [here](./update-system-path.md).
+    Firstly, go through Steps 1 – 3 shown in the “Update your system “Path” variable” section [here](update-system-path).
 
     Then come back here for the Next Step.
 

--- a/src/content/docs/troubleshoot/windows/List/win-issue-4.md
+++ b/src/content/docs/troubleshoot/windows/List/win-issue-4.md
@@ -11,7 +11,7 @@ description: A reference page in my new Starlight docs site.
 **Solution :**
 You might need to add the dotnet folder path to your “Path” environment variable.
 
-Firstly, go through Steps 1 – 3 shown in the “Update your system “Path” variable” section [here](./update-system-path.md)
+Firstly, go through Steps 1 – 3 shown in the “Update your system “Path” variable” section [here](update-system-path)
 
 Then come back here for the Next Step.
 

--- a/src/content/docs/troubleshoot/windows/List/win-issue-5.md
+++ b/src/content/docs/troubleshoot/windows/List/win-issue-5.md
@@ -9,7 +9,7 @@ description: A reference page in my new Starlight docs site.
 
 ## Solution :
 You might need to add the dotnet folder path to your “Path” environment variable.
-Firstly, go through Steps 1 – 3 shown in the “Update your system “Path” variable” section [here](./update-system-path.md).
+Firstly, go through Steps 1 – 3 shown in the “Update your system “Path” variable” section [here](update-system-path).
 
 Then come back here for the Next Step.
 **Next Step:** In the “Edit environment variable” window, click "New" (Red box), then add the

--- a/src/content/docs/troubleshoot/windows/windows.mdx
+++ b/src/content/docs/troubleshoot/windows/windows.mdx
@@ -20,5 +20,4 @@ sidebar:
 - [Issue 4](../list/win-issue-4): `Unable to find the .NET SDK`
 - [Issue 5](../list/win-issue-5) : "`dotnet: command not found`"
 - [Issue 6](../list/win-issue-6) : Error that mentions "(`are you missing an assembly reference?`)"
-
-- [Update System path](../list/update-system-path.md) Guide: Update Environment System path 
+- [Update System path](../list/update-system-path): Guide: Update Environment System path


### PR DESCRIPTION
### Description ###
I manually went through the entire splashkit.io website to find links which resulted in a **404 page not found** error and also I also analyzed links which redirected to wrong pages.  The links have been fixed except links in developer documentation as the mdx generating script needs to be changed. 

### Changes ###
I made changes to all the files necessary. The next section has documented links that resulted in errors. 

### Documentation ###
The documentation for the links that have been found and fixed can be found in this notion website: [https://gratis-chef-9b5.notion.site/Dead-wrong-redirection-Links-Splashkit-website-53913d4a84e74f3cbf592e7c67c3a662](url)

### Testing ###
I tested all the changes made to the code on my machine before creating the pull request. 

### Benefits ###
Fixed links will create better user experience as the user will be able to access information more seamlessly. This increase the user friendliness of the splashkit.io website. 

![404](https://github.com/thoth-tech/splashkit.io-starlight/assets/24810550/c50b7f43-ad2f-4d71-8d49-f9b7ae517779)

### Conclusion ###
**This pull request addresses broken and misdirected links on the splashkit.io website, ensuring a smoother user experience. By systematically identifying and fixing these issues, the website's usability and reliability are significantly enhanced.**
