### PR TITLE
Update guides to prevent users from inadvertently causing memory leaks

### DIFF
--- a/src/content/docs/guides/01-00-drawing.mdx
+++ b/src/content/docs/guides/01-00-drawing.mdx
@@ -3,7 +3,7 @@ title: Drawing using Procedures
 description: This article provide a quick overview of getting started with SplashKit. It includes how to create a window and do some basic drawing in order to create a small animation. This is a great place to start with SplashKit.
 category: Tutorials
 author: Andrew Cain
-lastupdated: May 30 2018
+lastupdated: May 10 2024
 ---
 
 **{frontmatter.description}**
@@ -15,7 +15,7 @@ In this article you will see how to get started with SplashKit with some simple 
 
 ## Step 1: Creating a Window
 
-In SplashKit you can open a Window to draw on and interact with. To open the window you need to call [open_window](/api/graphics/#open-window). This procedure requires you to pass it the window’s title, width and height. For example `open_window("House Drawing", 800, 600);` will open a window that is 800 pixels wide and 600 pixels high with the title "House Drawing", as shown in the following image. Please note that the house and hill are drawn by additional code.
+In SplashKit you can open a Window to draw on and interact with. To open the window you need to call [open_window](https://splashkit.io/api/windows/#open-window). This procedure requires you to pass it the window’s title, width and height. For example `open_window("House Drawing", 800, 600);` will open a window that is 800 pixels wide and 600 pixels high with the title "House Drawing", as shown in the following image. Please note that the house and hill are drawn by additional code. You must close the window when you are done using it, even if your program is otherwise finished. If you do not, the window will not be freed from memory when the program exits. You can close a window by calling a [close window](https://splashkit.io/api/windows/) function E.G. close_all_windows(). 
 
 <img
   alt="Window with dimensions illustrated"
@@ -34,9 +34,8 @@ In SplashKit you can open a Window to draw on and interact with. To open the win
 int main()
 {
     open_window("Window Title... to change", 800, 600);
-
     delay(5000);
-
+    close_all_windows();
     return 0;
 }
 ```
@@ -49,13 +48,12 @@ using SplashKitSDK;
 
 public class Program
 {
-public static void Main()
-{
-new Window("Window Title... to change", 800, 600);
-
+    public static void Main()
+    {
+        new Window("Window Title... to change", 800, 600);
         SplashKit.Delay(5000);
+        close_all_windows();
     }
-
 }
 
 ```
@@ -95,8 +93,9 @@ int main()
     fill_rectangle(COLOR_GRAY, 300, 300, 200, 200);
     fill_triangle(COLOR_RED, 250, 300, 400, 150, 550, 300);
     refresh_screen();
-
     delay(5000);
+    close_all_windows();
+    return 0;
 }
 ```
 
@@ -108,10 +107,10 @@ using SplashKitSDK;
 
 public class Program
 {
-public static void Main(string[] args)
-{
-Window shapesWindow;
-shapesWindow = new Window("Shapes by ...", 800, 600);
+    public static void Main(string[] args)
+    {
+        Window shapesWindow;
+        shapesWindow = new Window("Shapes by ...", 800, 600);
 
         shapesWindow.Clear(Color.White);
         shapesWindow.FillEllipse(Color.BrightGreen, 0, 400, 800, 400);
@@ -120,6 +119,7 @@ shapesWindow = new Window("Shapes by ...", 800, 600);
         shapesWindow.Refresh();
 
         SplashKit.Delay(5000);
+        close_all_windows();
     }
 
 }
@@ -190,4 +190,3 @@ You should be able to get Visual Studio Code to show you to list of parameters. 
 To draw a picture, like the house shown above, the computer executes the code to draw the individual shapes one at a time in the order they appear in the code (in **sequence**).  However, we dont want each element to appear individually, we just want the whole picture to appear at once, so in this case the whole house should show all at once. SplashKit uses a technique called **Double Buffering** to enable this. When double buffering, the computer first draws the shapes, then waits for a command to display the shapes to the user.  With SplashKit, the shapes are all shown together when you call the `refresh_screen` procedure. This is illustrated below.
 
 <img alt="Illustration of double buffering, and the need to refresh screen" src="/images/articles/starter/drawing/RefreshScreen.png" style="width: 700px"></img>
-


### PR DESCRIPTION
# Description
Small change to the documentation in response to a user reporting a memory leak in Splashkit. The user says that basic tutorial applications will leak memory. After some digging I believe this is caused by our documentation not explicitly telling the user to free resources that they create. As a result of this memory leaks when the program exits and the window object is not closed (and freed).  The tutorial now explicitly states that the user needs to consciously manage this resource. The example code has been updated accordingly. I have also touched up the example code in a couple of places where it was not indented correctly.
## Type of change
- [X] Documentation

## How Has This Been Tested?
Checked the markdown file locally to make sure that the formatting still looks consistent. Have tested the sample code to ensure that it still works. 

## Testing Checklist
- [] Tested with sktest
- [] Tested with skunit_tests

## Checklist
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have requested a review from ... on the Pull Request
