### PR TITLE
Language update to Clear screen-background colour usage example

### DIFF
--- a/public/usage-examples/graphics/clear_screen/clear_screen-1-simple-oop.cs
+++ b/public/usage-examples/graphics/clear_screen/clear_screen-1-simple-oop.cs
@@ -1,22 +1,19 @@
 ﻿using SplashKitSDK;
 
-namespace ClearScreen 
+namespace ClearScreenExample
 {
-    public class Program 
+    public class Program
     {
         public static void Main()
         {
-            //Open new window with title and dimensions
             SplashKit.OpenWindow("Blue Background", 800, 600);
 
-            //Use Clear Screen to change the background color to blue 
+            //Use Clear Screen to change the background color to blue
             SplashKit.ClearScreen(Color.Blue);
+
             SplashKit.RefreshScreen(60);
             SplashKit.Delay(4000);
-            
-            //Close loaded windows 
             SplashKit.CloseAllWindows();
         }
     }
-
 }

--- a/public/usage-examples/graphics/clear_screen/clear_screen-1-simple-oop.cs
+++ b/public/usage-examples/graphics/clear_screen/clear_screen-1-simple-oop.cs
@@ -1,0 +1,22 @@
+﻿using SplashKitSDK;
+
+namespace ClearScreen 
+{
+    public class Program 
+    {
+        public static void Main()
+        {
+            //Open new window with title and dimensions
+            SplashKit.OpenWindow("Blue Background", 800, 600);
+
+            //Use Clear Screen to change the background color to blue 
+            SplashKit.ClearScreen(Color.Blue);
+            SplashKit.RefreshScreen(60);
+            SplashKit.Delay(4000);
+            
+            //Close loaded windows 
+            SplashKit.CloseAllWindows();
+        }
+    }
+
+}

--- a/public/usage-examples/graphics/clear_screen/clear_screen-1-simple-top-level.cs
+++ b/public/usage-examples/graphics/clear_screen/clear_screen-1-simple-top-level.cs
@@ -1,9 +1,12 @@
 using static SplashKitSDK.SplashKit;
 
+//Open new window with title and dimensions
 OpenWindow("Blue Background", 800, 600);
 
+//Use Clear Screen to change the background color to blue 
 ClearScreen(ColorBlue());
 RefreshScreen(60);
 Delay(4000);
 
+//Close loaded windows   
 CloseAllWindows();

--- a/public/usage-examples/graphics/clear_screen/clear_screen-1-simple-top-level.cs
+++ b/public/usage-examples/graphics/clear_screen/clear_screen-1-simple-top-level.cs
@@ -1,12 +1,10 @@
 using static SplashKitSDK.SplashKit;
 
-//Open new window with title and dimensions
 OpenWindow("Blue Background", 800, 600);
 
 //Use Clear Screen to change the background color to blue 
 ClearScreen(ColorBlue());
+
 RefreshScreen(60);
 Delay(4000);
-
-//Close loaded windows   
 CloseAllWindows();

--- a/public/usage-examples/graphics/clear_screen/clear_screen-1-simple.cpp
+++ b/public/usage-examples/graphics/clear_screen/clear_screen-1-simple.cpp
@@ -2,15 +2,13 @@
 
 int main()
 {
-    //Open new window with title and dimensions
     open_window("Blue Background", 800, 600);
 
     //Use Clear Screen to change the background color to blue 
     clear_screen(COLOR_BLUE);
+
     refresh_screen(60);
     delay(4000);
-    
-    //Close loaded windows   
     close_all_windows();
 
     return 0;

--- a/public/usage-examples/graphics/clear_screen/clear_screen-1-simple.cpp
+++ b/public/usage-examples/graphics/clear_screen/clear_screen-1-simple.cpp
@@ -1,15 +1,16 @@
 #include "splashkit.h"
 
-#include "splashkit.h"
-
 int main()
 {
+    //Open new window with title and dimensions
     open_window("Blue Background", 800, 600);
-    
+
+    //Use Clear Screen to change the background color to blue 
     clear_screen(COLOR_BLUE);
     refresh_screen(60);
     delay(4000);
-
+    
+    //Close loaded windows   
     close_all_windows();
 
     return 0;

--- a/public/usage-examples/graphics/clear_screen/clear_screen-1-simple.py
+++ b/public/usage-examples/graphics/clear_screen/clear_screen-1-simple.py
@@ -1,0 +1,12 @@
+from splashkit import *
+
+# Open new window with title and dimensions
+open_window("Blue Background", 800, 600)
+
+# Use Clear Screen to change the background color to blue 
+clear_screen(color_blue())
+refresh_screen()
+delay(4000)
+
+# Close loaded windows 
+close_all_windows()

--- a/public/usage-examples/graphics/clear_screen/clear_screen-1-simple.py
+++ b/public/usage-examples/graphics/clear_screen/clear_screen-1-simple.py
@@ -1,12 +1,10 @@
 from splashkit import *
 
-# Open new window with title and dimensions
 open_window("Blue Background", 800, 600)
 
 # Use Clear Screen to change the background color to blue 
 clear_screen(color_blue())
+
 refresh_screen()
 delay(4000)
-
-# Close loaded windows 
 close_all_windows()


### PR DESCRIPTION
The example demonstrates how to use the Clear screen function to make the screen background blue, user can change the colour as they wish. I have updated the language to include C# (OOP) and Python

Splashkit Function: `Clear Screen`

# Files Included
- [ ] Title and explanation (.txt)
- [ ] C++ code
- [ ] C# code (top-level statements)
- [x] C# code (Object-Oriented Programming)
- [x] Python code
- [ ] Screenshot

# Usage Example Checks
- [x] Simple, clear demonstration of the function
- [x] Code uses Splashkit functions
- [x] Tested in Chrome and Firefox

Additional Changes
- Added comments to the existing example
- Removed the redundant "include SplashKit" in the C++ code