### PR TITLE
Incorporate Google Analytics

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -4,6 +4,7 @@ import solidJs from "@astrojs/solid-js";
 import react from "@astrojs/react";
 import starlightLinksValidator from 'starlight-links-validator';
 import sitemap from "@astrojs/sitemap";
+import partytown from '@astrojs/partytown';
 
 // https://astro.build/config
 export default defineConfig({
@@ -15,6 +16,26 @@ export default defineConfig({
     starlight({
       title: "SplashKit",
       description: 'SplashKit is a cross-platform game engine for C, C++ and Objective-C. It provides a simple API for 2D game development.',
+      head: [
+        // Google Analytics script tag
+        {
+          tag: 'script',
+          attrs: {
+            async: true,
+            src: 'https://www.googletagmanager.com/gtag/js?id=G-1HKE1PH6ZM',
+          },
+        },
+        // Google Analytics inline configuration
+        {
+          tag: 'script',
+          children: `
+            window.dataLayer = window.dataLayer || [];
+            function gtag(){dataLayer.push(arguments);}
+            gtag('js', new Date());
+            gtag('config', 'G-1HKE1PH6ZM');
+          `,
+        },
+      ],
       plugins: [
         starlightLinksValidator({
           errorOnRelativeLinks: true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.9",
       "dependencies": {
         "@astrojs/netlify": "^5.4.0",
+        "@astrojs/partytown": "^2.1.2",
         "@astrojs/prism": "^3.1.0",
         "@astrojs/react": "^3.6.0",
         "@astrojs/sitemap": "^3.1.6",
@@ -211,6 +212,16 @@
       },
       "peerDependencies": {
         "astro": "^4.2.0"
+      }
+    },
+    "node_modules/@astrojs/partytown": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@astrojs/partytown/-/partytown-2.1.2.tgz",
+      "integrity": "sha512-1a9T5lqxtnrw0qLPo1KwliUvaaUzPNPtWucD8VxdwT7zqcpODFk1RzGgAgqVo+YhutFrTu/qclbtnOfXBuskjw==",
+      "license": "MIT",
+      "dependencies": {
+        "@builder.io/partytown": "^0.10.2",
+        "mrmime": "^2.0.0"
       }
     },
     "node_modules/@astrojs/prism": {
@@ -667,6 +678,18 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@builder.io/partytown": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@builder.io/partytown/-/partytown-0.10.2.tgz",
+      "integrity": "sha512-A9U+4PREWcS+CCYzKGIPovtGB/PBgnH/8oQyCE6Nr9drDJk6cMPpLQIEajpGPmG9tYF7N3FkRvhXm/AS9+0iKg==",
+      "license": "MIT",
+      "bin": {
+        "partytown": "bin/partytown.cjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@ctrl/tinycolor": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "@astrojs/netlify": "^5.4.0",
+    "@astrojs/partytown": "^2.1.2",
     "@astrojs/prism": "^3.1.0",
     "@astrojs/react": "^3.6.0",
     "@astrojs/sitemap": "^3.1.6",


### PR DESCRIPTION
# Description

This pull request incorporates Google Analytics into the SplashKit website to enable website traffic tracking and analytics. The implementation uses the `head` field in `astro.config.mjs` to inject the required `<script>` tags into the site's `<head>` section. This change ensures analytics functionality is seamlessly integrated.

### Motivation
Tracking user interactions on the website will help the team make informed decisions to improve the user experience, prioritize features, and gauge the effectiveness of content.

### Dependencies
No additional dependencies are required for this change.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Testing of functionality can only be done once incorporated, however if the tag is not communicating back to Google Analytics, it will not break any existing functionality. Once merged, I will check that the analytics tag is correctly reporting data using the [Google Tag Assistant](https://tagassistant.google.com/).
I have also ensured the implementation does not interfere with existing website functionality.

## Testing Checklist

- [x] Tested in latest Chrome
- [x] Tested in latest Firefox
- [x] npm run build
- [x] npm run preview

## Checklist

### If involving code

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code in hard-to-understand areas.
- [x] My changes generate no new warnings.

### If modified config files

- [x] I have checked the following files for changes:
  - [x] package.json (incorporated partytown)
  - [x] astro.config.mjs
  - [x] netlify.toml (no changes made)
  - [x] docker-compose.yml (no changes made)
  - [x] custom.css (no changes made)

## Folders and Files Added/Modified

- Modified:
  - [x] astro.config.mjs
  - [x] package.json
  - [x] package-lock.json 
