### PR TITLE
Adding nested tab for cpp for Beyond SplashKit in usage examples & updating draw bitmap named usage example

### DIFF
--- a/public/usage-examples/graphics/draw_bitmap_named/draw_bitmap_named-1-simple-beyond.cpp
+++ b/public/usage-examples/graphics/draw_bitmap_named/draw_bitmap_named-1-simple-beyond.cpp
@@ -1,0 +1,104 @@
+#include <iostream>
+#ifdef __APPLE__
+#include <SDL.h>
+#include <SDL_image.h>
+#else
+#include <SDL2/SDL.h>
+#include <SDL2/SDL_image.h>
+#endif
+
+SDL_Window *sdl_open_window(const char *window_title, const int width, const int height)
+{
+    // Declare Variables
+    SDL_Window *window = nullptr;
+
+    // Check for successful initialisation
+    if (SDL_Init(SDL_INIT_VIDEO) < 0)
+    {
+        std::cout << "SDL could not be initialized: " << SDL_GetError();
+        exit(1);
+    }
+
+    // Create Window
+    window = SDL_CreateWindow(
+        window_title,
+        SDL_WINDOWPOS_CENTERED,
+        SDL_WINDOWPOS_CENTERED,
+        width,
+        height,
+        SDL_WINDOW_OPENGL);
+
+    // Error handling for window
+    if (window == NULL)
+    {
+        SDL_LogError(SDL_LOG_CATEGORY_ERROR, "Could not create window: %s\n", SDL_GetError());
+        exit(1);
+    }
+
+    return window;
+}
+
+SDL_Renderer *sdl_create_renderer(SDL_Window *window)
+{
+    SDL_Renderer *renderer = SDL_CreateRenderer(window, -1, SDL_RENDERER_ACCELERATED);
+    if (renderer == NULL)
+    {
+        SDL_LogError(SDL_LOG_CATEGORY_ERROR, "Could not create rederer: %s\n", SDL_GetError());
+        exit(1);
+    }
+    return renderer;
+}
+
+int main(int argv, char **args)
+{
+    SDL_Window *window = sdl_open_window("Basic Bitmap Drawing", 315, 330);
+    SDL_Renderer *renderer = sdl_create_renderer(window);
+
+    // Load image
+    // Create a surface for imported image
+    SDL_Surface *image = IMG_Load("Resources/images/skbox.png");
+    if (image == NULL)
+    {
+        std::cout << "Failed to load skbox.png" << SDL_GetError();
+        exit(1);
+    }
+
+    // Convert surface to texture
+    SDL_Texture *image_texture = SDL_CreateTextureFromSurface(renderer, image);
+    if (image_texture == NULL)
+    {
+        std::cout << "Failed to create texture" << SDL_GetError();
+        exit(1);
+    }
+
+    // Free memory
+    SDL_FreeSurface(image);
+
+    // Get image size to avoid stretching
+    int background_width = 0, background_height = 0;
+    SDL_QueryTexture(image_texture, NULL, NULL, &background_width, &background_height);
+
+    // Hang window until quit
+    SDL_Event event;
+    while (event.type != SDL_QUIT)
+    {
+        SDL_PollEvent(&event);
+
+        // Clear screen with blue
+        SDL_SetRenderDrawColor(renderer, 67, 80, 175, 255);
+        SDL_RenderClear(renderer);
+
+        // Draw image to screen
+        SDL_Rect image_rect = { 50, 50, background_width, background_height };
+        SDL_RenderCopy(renderer, image_texture, NULL, &image_rect);
+
+        // Display drawing
+        SDL_RenderPresent(renderer);
+    }
+
+    // Cleanup and free memory
+    SDL_DestroyWindow(window);
+    SDL_DestroyRenderer(renderer);
+
+    return 0;
+}

--- a/public/usage-examples/graphics/draw_bitmap_named/draw_bitmap_named-1-simple-beyond.cpp
+++ b/public/usage-examples/graphics/draw_bitmap_named/draw_bitmap_named-1-simple-beyond.cpp
@@ -51,10 +51,11 @@ SDL_Renderer *sdl_create_renderer(SDL_Window *window)
 
 int main(int argv, char **args)
 {
+    // Open Window
     SDL_Window *window = sdl_open_window("Basic Bitmap Drawing", 315, 330);
     SDL_Renderer *renderer = sdl_create_renderer(window);
 
-    // Load image
+    // Load bitmap image
     // Create a surface for imported image
     SDL_Surface *image = IMG_Load("Resources/images/skbox.png");
     if (image == NULL)

--- a/public/usage-examples/graphics/draw_bitmap_named/draw_bitmap_named-1-simple-oop.cs
+++ b/public/usage-examples/graphics/draw_bitmap_named/draw_bitmap_named-1-simple-oop.cs
@@ -6,10 +6,11 @@ namespace DrawBitmapNamed
     {
         public static void Main()
         {
-
+            // Open Window
             Window window = new Window("Basic Bitmap Drawing", 315, 330);
 
-            SplashKit.LoadBitmap("skbox", "skbox.png"); // Load bitmap image
+            // Load bitmap image
+            SplashKit.LoadBitmap("skbox", "skbox.png");
 
             while (!window.CloseRequested)
             {

--- a/public/usage-examples/graphics/draw_bitmap_named/draw_bitmap_named-1-simple-sk.cpp
+++ b/public/usage-examples/graphics/draw_bitmap_named/draw_bitmap_named-1-simple-sk.cpp
@@ -15,6 +15,7 @@ int main()
         refresh_screen();
     }
     close_all_windows();
+    free_all_bitmaps();
 
     return 0;
 }

--- a/public/usage-examples/graphics/draw_bitmap_named/draw_bitmap_named-1-simple-sk.cpp
+++ b/public/usage-examples/graphics/draw_bitmap_named/draw_bitmap_named-1-simple-sk.cpp
@@ -2,9 +2,11 @@
 
 int main()
 {
+    // Open Window
     open_window("Basic Bitmap Drawing", 315, 330);
 
-    load_bitmap("skbox", "skbox.png"); // Load bitmap image
+    // Load bitmap image
+    load_bitmap("skbox", "skbox.png");
 
     while (!quit_requested())
     {

--- a/public/usage-examples/graphics/draw_bitmap_named/draw_bitmap_named-1-simple-top-level.cs
+++ b/public/usage-examples/graphics/draw_bitmap_named/draw_bitmap_named-1-simple-top-level.cs
@@ -1,8 +1,10 @@
 using static SplashKitSDK.SplashKit;
 
+// Open Window
 OpenWindow("Basic Bitmap Drawing", 315, 330);
 
-LoadBitmap("skbox", "skbox.png"); // Load bitmap image
+// Load bitmap image
+LoadBitmap("skbox", "skbox.png"); 
 
 while (!QuitRequested())
 {

--- a/public/usage-examples/graphics/draw_bitmap_named/draw_bitmap_named-1-simple.py
+++ b/public/usage-examples/graphics/draw_bitmap_named/draw_bitmap_named-1-simple.py
@@ -1,8 +1,10 @@
 from splashkit import *
 
+# Open Window
 open_window("Basic Bitmap Drawing", 315, 330)
 
-load_bitmap("skbox", "skbox.png") # Load bitmap image
+# Load bitmap image
+load_bitmap("skbox", "skbox.png")
 
 while (not quit_requested()):
     process_events()

--- a/scripts/usage-example-page-generation.cjs
+++ b/scripts/usage-example-page-generation.cjs
@@ -391,7 +391,7 @@ categories.forEach((categoryKey) => {
               }
             }
           });
-          console.log("Generated Imports for C++:\n", mdxContent);
+          // console.log("Generated Imports for C++:\n", mdxContent);
           mdxContent += "\n";
 
           // Code tabs
@@ -447,6 +447,7 @@ categories.forEach((categoryKey) => {
                     }
                     if (file.includes("-beyond")) {
                       mdxContent += `    <TabItem label="Beyond SplashKit">\n`;
+                      mdxContent += `      See the [Graphics](https://splashkit.io/beyond-splashkit/graphics/0-getting-started-with-graphics/#getting-started-without-splashkit) or [Audio](https://splashkit.io/beyond-splashkit/audio/0-sound-effects/#getting-started-without-splashkit) Beyond SplashKit guides for help compiling without SplashKit.\n`;
                       mdxContent += `      <Code code={${importTitle}_beyond_${lang}} lang="${lang}" mark={"SplashKit.${functionTag}"} />\n`;
                       mdxContent += "    </TabItem>\n";
                     }
@@ -461,7 +462,7 @@ categories.forEach((categoryKey) => {
               }
             }
           });
-          console.log("Generated Imports for C++:\n", mdxContent);
+          // console.log("Generated Imports for C++:\n", mdxContent); // Debugging
           mdxContent += "</Tabs>\n\n";
 
           // Image or gif output

--- a/scripts/usage-example-page-generation.cjs
+++ b/scripts/usage-example-page-generation.cjs
@@ -289,8 +289,7 @@ categories.forEach((categoryKey) => {
 
             // Define required code files
             const requiredCodeFiles = {
-              "-sk.cpp": "C++ (SplashKit)",
-              "-beyond.cpp": "C++ (Beyond)",
+              ".cpp": "C++\t\t",
               "-top-level.cs": "C# (Top-Level)",
               "-oop.cs": "C# (Object-Oriented)",
               ".py": "Python\t",

--- a/scripts/usage-example-page-generation.cjs
+++ b/scripts/usage-example-page-generation.cjs
@@ -289,7 +289,8 @@ categories.forEach((categoryKey) => {
 
             // Define required code files
             const requiredCodeFiles = {
-              ".cpp": "C++\t\t",
+              "-sk.cpp": "C++ (SplashKit)",
+              "-beyond.cpp": "C++ (Beyond)",
               "-top-level.cs": "C# (Top-Level)",
               "-oop.cs": "C# (Object-Oriented)",
               ".py": "Python\t",
@@ -361,6 +362,7 @@ categories.forEach((categoryKey) => {
 
               // Check if both top level and oop code has been found for current function
               const csharpFiles = codeFiles.filter(file => file.endsWith("-top-level.cs") || file.endsWith("-oop.cs")).filter(file => file.includes(exampleKey));
+              const cppFiles = codeFiles.filter(file => file.endsWith("-sk.cpp") || file.endsWith("-beyond.cpp")).filter(file => file.includes(exampleKey));
               if (lang == "csharp" && csharpFiles.length > 0) {
                 csharpFiles.forEach(file => {
                   if (file.includes(exampleKey)) {
@@ -372,13 +374,25 @@ categories.forEach((categoryKey) => {
                     }
                   }
                 });
-              }
+              } // Check for cpp files for standard SK and Beyond SK
+              else if (lang == "cpp" && cppFiles.length > 0) {
+                cppFiles.forEach(file => {
+                  if (file.includes(exampleKey)){
+                    if (file.includes("-sk")){
+                      mdxContent += `import ${importTitle}_sk_${lang} from '${codeFilePath.replaceAll(".cpp", "-sk.cpp").replaceAll("/usage", "/public/usage")}?raw';\n`;
+                    }
+                    if (file.includes("-beyond")){
+                      mdxContent += `import ${importTitle}_beyond_${lang} from '${codeFilePath.replaceAll(".cpp", "-beyond.cpp").replaceAll("/usage", "/public/usage")}?raw';\n`;
+                    }
+                  }
+              });
+            }
               else {
                 mdxContent += `import ${importTitle}_${lang} from '${codeFilePath.replaceAll("/usage", "/public/usage")}?raw';\n`;
               }
             }
           });
-
+          console.log("Generated Imports for C++:\n", mdxContent);
           mdxContent += "\n";
 
           // Code tabs
@@ -391,9 +405,12 @@ categories.forEach((categoryKey) => {
 
               // Check if both top level and oop code has been found for current function
               const csharpFiles = codeFiles.filter(file => file.endsWith("-top-level.cs") || file.endsWith("-oop.cs")).filter(file => file.includes(exampleKey));
+              const cppFiles = codeFiles.filter(file => file.endsWith("-sk.cpp") || file.endsWith("-beyond.cpp")).filter(file => file.includes(exampleKey));
               functionTag = exampleKey.split("-")[0];
               if (lang == "cpp") {
-                functionTag = groupName;
+                functionTag = groupName.split("_")
+                  .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+                  .join("");
               }
               if (lang == "csharp") {
                 functionTag = groupName.split("_")
@@ -419,14 +436,33 @@ categories.forEach((categoryKey) => {
                 });
                 mdxContent += "  </Tabs>\n\n";
                 mdxContent += "  </TabItem>\n";
+              } // Check for cpp files and generate nested tabs
+              else if (lang == "cpp" && cppFiles.length > 0) {
+                mdxContent += "\n <Tabs syncKey=\"cpp-style\">\n";
+                cppFiles.slice().reverse().forEach(file => {
+                  if (file.includes(exampleKey)) {
+                    if (file.includes("-sk")) {
+                      mdxContent += `    <TabItem label="SplashKit">\n`;
+                      mdxContent += `      <Code code={${importTitle}_sk_${lang}} lang="${lang}" mark={"${functionTag}"} />\n`;
+                      mdxContent += "    </TabItem>\n";
+                    }
+                    if (file.includes("-beyond")) {
+                      mdxContent += `    <TabItem label="Beyond SplashKit">\n`;
+                      mdxContent += `      <Code code={${importTitle}_beyond_${lang}} lang="${lang}" mark={"SplashKit.${functionTag}"} />\n`;
+                      mdxContent += "    </TabItem>\n";
+                    }
+                  }
+                });
+                mdxContent += "  </Tabs>\n\n";
+                mdxContent += "  </TabItem>\n";
               }
               else {
                 mdxContent += `    <Code code={${importTitle}_${lang}} lang="${lang}" mark={"${functionTag}"} />\n`;
                 mdxContent += "  </TabItem>\n";
               }
             }
-
           });
+          console.log("Generated Imports for C++:\n", mdxContent);
           mdxContent += "</Tabs>\n\n";
 
           // Image or gif output

--- a/src/content/docs/usage-examples/CONTRIBUTING.mdx
+++ b/src/content/docs/usage-examples/CONTRIBUTING.mdx
@@ -101,9 +101,9 @@ Please follow the guidelines below:
 - Make sure to include 4 code files:
   1. `.cpp` file using SplashKit
   2. `.cpp` file using Beyond SplashKit
-  2. `.cs` file using top-level statements style
-  3. `.cs` file using object-oriented style
-  4. `.py` file
+  3. `.cs` file using top-level statements style
+  4. `.cs` file using object-oriented style
+  5. `.py` file
 
 ## Write Line Examples
 

--- a/src/content/docs/usage-examples/CONTRIBUTING.mdx
+++ b/src/content/docs/usage-examples/CONTRIBUTING.mdx
@@ -32,7 +32,8 @@ Here is an example of files for two code examples added for the `write_line` fun
 ```plaintext
 write_line-1-simple-oop.cs
 write_line-1-simple-top-level.cs
-write_line-1-simple.cpp
+write_line-1-simple-sk.cpp
+write-line-1-simple-beyond.cpp
 write_line-1-simple.png
 write_line-1-simple.py
 write_line-1-simple.txt
@@ -98,10 +99,12 @@ Please follow the guidelines below:
 - All of the example code needs to be in a single file.
 - Example code should be able to be run by copying the code into an empty code file.
 - Make sure to include 4 code files:
-  1. `.cpp` file
+  1. `.cpp` file using SplashKit
   2. `.cs` file using top-level statements style
   3. `.cs` file using object-oriented style
   4. `.py` file
+- Additional code file: 
+  1. `.cpp` file using Beyond SplashKit
 
 ## Write Line Examples
 

--- a/src/content/docs/usage-examples/CONTRIBUTING.mdx
+++ b/src/content/docs/usage-examples/CONTRIBUTING.mdx
@@ -98,9 +98,9 @@ Please follow the guidelines below:
 
 - All of the example code needs to be in a single file.
 - Example code should be able to be run by copying the code into an empty code file.
-- Make sure to include 4 code files:
+- Make sure to include 5 code files:
   1. `.cpp` file using SplashKit
-  2. `.cpp` file using Beyond SplashKit
+  2. `.cpp` file using Beyond SplashKit (without SplashKit)
   3. `.cs` file using top-level statements style
   4. `.cs` file using object-oriented style
   5. `.py` file

--- a/src/content/docs/usage-examples/CONTRIBUTING.mdx
+++ b/src/content/docs/usage-examples/CONTRIBUTING.mdx
@@ -100,11 +100,10 @@ Please follow the guidelines below:
 - Example code should be able to be run by copying the code into an empty code file.
 - Make sure to include 4 code files:
   1. `.cpp` file using SplashKit
+  2. `.cpp` file using Beyond SplashKit
   2. `.cs` file using top-level statements style
   3. `.cs` file using object-oriented style
   4. `.py` file
-- Additional code file: 
-  1. `.cpp` file using Beyond SplashKit
 
 ## Write Line Examples
 


### PR DESCRIPTION
# Description

This is a PR for an additional nested tab in the C++ section of usage examples for Beyond SplashKit. I have also updated the CONTRIBUTING file to include guides for file naming with Beyond SK files. The normal SK file will have -sk.cpp and Beyond SK files have -beyond.cpp.

I have also added the without SplashKit version into the Draw Bitmap usage example using the nested tab. This uses the same code as in the [Draw Bitmap](https://splashkit.io/beyond-splashkit/graphics/0-getting-started-with-graphics/#draw-bitmap) section of Beyond SplashKit, with just minor changes to match the existing output in the usage example. Also added free all bitmap to the SK code to align with the beyond SK code. 

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation (update or new)

## How Has This Been Tested?

Tested by adding dummy files with -sk.cpp and -beyond.cpp to a few usage examples and running npm run build and preview on Chrome, Firefox and Safari to ensure the code is presented properly.

## Testing Checklist

- [x] Tested in latest Chrome
- [x] Tested in latest Firefox
- [x] npm run build
- [x] npm run preview

## Checklist

### If involving code

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Folders and Files Added/Modified

- Added:
  - [x] draw_bitmap_named-1-simple-beyond.cpp
- Modified:
  - [x] CONTRIBUTING.mdx
  - [x] usage-example-page-generation.cjs
  - [x] draw_bitmap_named-1-simple-sk.cpp

