### PR TITLE
New troubleshooting page for MacOS: zshrc issue

### DIFF
--- a/src/content/docs/troubleshoot/MacOS/index.mdx
+++ b/src/content/docs/troubleshoot/MacOS/index.mdx
@@ -8,7 +8,7 @@ sidebar:
     class: apple
 ---
 
-*This repository provides solutions to known installation issues encountered by Mac users while installing SplashKit. If you are facing any problems with SplashKit, refer to this document for possible solutions.*
+_This repository provides solutions to known installation issues encountered by Mac users while installing SplashKit. If you are facing any problems with SplashKit, refer to this document for possible solutions._
 
 | Link                                       | Description                                                                                                         |
 | ------------------------------------------ | ------------------------------------------------------------------------------------------------------------------- |
@@ -18,3 +18,4 @@ sidebar:
 | [Issue_4](/troubleshoot/macos/mac-issue-4) | `System.DllNotFoundException unable to load DLL splashkit.dll` when trying to run program                           |
 | [Issue_5](/troubleshoot/macos/mac-issue-5) | `zsh: command not found: skm`                                                                                       |
 | [Issue_6](/troubleshoot/macos/mac-issue-6) | Error mentioning `are you missing an assembly reference?`                                                           |
+| [Issue_7](/troubleshoot/macos/mac-issue-7) | `ModuleNotFoundError: No module named 'splashkit'` when running Python programs                                     |

--- a/src/content/docs/troubleshoot/MacOS/index.mdx
+++ b/src/content/docs/troubleshoot/MacOS/index.mdx
@@ -8,7 +8,7 @@ sidebar:
     class: apple
 ---
 
-_This repository provides solutions to known installation issues encountered by Mac users while installing SplashKit. If you are facing any problems with SplashKit, refer to this document for possible solutions._
+*This repository provides solutions to known installation issues encountered by Mac users while installing SplashKit. If you are facing any problems with SplashKit, refer to this document for possible solutions.*
 
 | Link                                       | Description                                                                                                         |
 | ------------------------------------------ | ------------------------------------------------------------------------------------------------------------------- |

--- a/src/content/docs/troubleshoot/MacOS/mac-issue-7.mdx
+++ b/src/content/docs/troubleshoot/MacOS/mac-issue-7.mdx
@@ -2,24 +2,20 @@
 title: No module named 'splashkit' in Python error
 description: Python code files are unable to find the splashkit dependancy installed in Homebrew.
 sidebar:
-  label: 7. ModuleNotFoundError
-#  attrs:
-#    class: apple
+  label: "7. Python ModuleNotFoundError"
 ---
 
 import { Steps } from "@astrojs/starlight/components";
 
-<h1> Issue : MacOS </h1>
+:::caution[ModuleNotFoundError: No module named 'splashkit' in Python]
 
-### `ModuleNotFoundError: No module named 'splashkit' in Python`
+This guide helps resolve the error `ModuleNotFoundError: No module named 'splashkit' in Python` on MacOS. This issue occurs when the Homebrew path is not correctly set in the `.zshrc` file as SplashKit's global python library is added in using the path where the Homebrew version of Python is present.
 
-**Description:** This guide helps resolve the error `ModuleNotFoundError: No module named 'splashkit' in Python` on MacOS. This issue occurs when Python is installed through Homebrew and the SplashKit path is not correctly set in the `.zshrc` file where the Homebrew version of Python is present.
-
----
+:::
 
 ## Problem
 
-MacOS prioritises its built-in Python installation located in `/usr/bin/python3`. SplashKit and other dependencies are installed in the Python environment managed by Homebrew, which is located at `/opt/homebrew/bin/python3` or similar paths. Due to this, the SplashKit module cannot be located in shell’s environment variables (`PATH`).
+MacOS prioritises its built-in Python installation located in `/usr/bin/python3`. SplashKit and other dependencies are likely installed in the Python environment managed by Homebrew, which is located at `/opt/homebrew/bin/python3` or similar. Due to this, the SplashKit module cannot be located in shell’s environment variables (`PATH`).
 
 ![Error Example](https://i.imgur.com/1HMsz87.png)
 
@@ -35,7 +31,7 @@ To resolve this, add this line: `eval "$(/opt/homebrew/bin/brew shellenv)"` to y
 
    If you don’t see it, press **Shift + Command + . (dot)** to toggle hidden files visibility in Finder.
 
-2. **Identify Your Username (Optional)**
+   :::tip[Identify Your Username]
 
    To ensure you’re in the correct directory, you can use the `whoami` command in Terminal to check your username:
 
@@ -45,15 +41,17 @@ To resolve this, add this line: `eval "$(/opt/homebrew/bin/brew shellenv)"` to y
 
    ![Username Check Example](https://i.imgur.com/Le4nSdA.png)
 
-3. **Add SplashKit to PATH**
+   :::
 
-   To ensure macOS uses the Homebrew-installed version of Python, open the `.zshrc` file with a text editor and add the following line at the start to include the SplashKit path:
+2. **Add 'homebrew' path**
+
+   To ensure macOS uses the Homebrew-installed version of Python, open the `.zshrc` file with a text editor and add the following line at the start to include the homebrew path:
 
    ```shell
    eval "$(/opt/homebrew/bin/brew shellenv)"
    ```
 
-4. **Apply Changes**
+3. **Apply Changes**
 
    Save the `.zshrc` file and then reload it with the following command to apply changes immediately:
 
@@ -61,7 +59,7 @@ To resolve this, add this line: `eval "$(/opt/homebrew/bin/brew shellenv)"` to y
    source ~/.zshrc
    ```
 
-5. **Check Python version**
+4. **Check Python version**
 
    Verify that the terminal is using the Homebrew-installed Python version:
 
@@ -75,7 +73,7 @@ To resolve this, add this line: `eval "$(/opt/homebrew/bin/brew shellenv)"` to y
    /opt/homebrew/bin/python3
    ```
 
-6. **Test the setup**
+5. **Test the setup**
 
    Run your Python script again. It should now successfully locate the SplashKit module.
 

--- a/src/content/docs/troubleshoot/MacOS/mac-issue-7.mdx
+++ b/src/content/docs/troubleshoot/MacOS/mac-issue-7.mdx
@@ -1,0 +1,84 @@
+---
+title: No module named 'splashkit' in Python error
+description: Python code files are unable to find the splashkit dependancy installed in Homebrew.
+sidebar:
+  label: 7. ModuleNotFoundError
+#  attrs:
+#    class: apple
+---
+
+import { Steps } from "@astrojs/starlight/components";
+
+<h1> Issue : MacOS </h1>
+
+### `ModuleNotFoundError: No module named 'splashkit' in Python`
+
+**Description:** This guide helps resolve the error `ModuleNotFoundError: No module named 'splashkit' in Python` on MacOS. This issue occurs when Python is installed through Homebrew and the SplashKit path is not correctly set in the `.zshrc` file where the Homebrew version of Python is present.
+
+---
+
+## Problem
+
+MacOS prioritises its built-in Python installation located in `/usr/bin/python3`. SplashKit and other dependencies are installed in the Python environment managed by Homebrew, which is located at `/opt/homebrew/bin/python3` or similar paths. Due to this, the SplashKit module cannot be located in shell’s environment variables (`PATH`).
+
+![Error Example](https://i.imgur.com/1HMsz87.png)
+
+## Solution
+
+To resolve this, add this line: `eval "$(/opt/homebrew/bin/brew shellenv)"` to your `.zshrc` file. Follow the steps below:
+
+<Steps>
+
+1. **Locate Your `.zshrc` File**
+
+   The `.zshrc` file is located in your home directory at `~/Users/(your username)/`.
+
+   If you don’t see it, press **Shift + Command + . (dot)** to toggle hidden files visibility in Finder.
+
+2. **Identify Your Username (Optional)**
+
+   To ensure you’re in the correct directory, you can use the `whoami` command in Terminal to check your username:
+
+   ```shell
+   whoami
+   ```
+
+   ![Username Check Example](https://i.imgur.com/Le4nSdA.png)
+
+3. **Add SplashKit to PATH**
+
+   To ensure macOS uses the Homebrew-installed version of Python, open the `.zshrc` file with a text editor and add the following line at the start to include the SplashKit path:
+
+   ```shell
+   eval "$(/opt/homebrew/bin/brew shellenv)"
+   ```
+
+4. **Apply Changes**
+
+   Save the `.zshrc` file and then reload it with the following command to apply changes immediately:
+
+   ```shell
+   source ~/.zshrc
+   ```
+
+5. **Check Python version**
+
+   Verify that the terminal is using the Homebrew-installed Python version:
+
+   ```shell
+   which python3
+   ```
+
+   The output should be something like:
+
+   ```shell
+   /opt/homebrew/bin/python3
+   ```
+
+6. **Test the setup**
+
+   Run your Python script again. It should now successfully locate the SplashKit module.
+
+</Steps>
+
+After completing these steps, your terminal will use the Homebrew-installed version of Python, and your Python script should now successfully find and run the SplashKit module without encountering the `ModuleNotFoundError`.


### PR DESCRIPTION
# Description

Issue: Python Module Not Found – SplashKit on macOS On macOS

Users may encounter the following error when trying to run Python files that use the SplashKit library
`ModuleNotFoundError: No module named 'splashkit' `

Cause: This issue occurs because macOS defaults to using the version of Python installed in its own system library, rather than the version installed via Homebrew (which is often where SplashKit and other dependencies are installed). As a result, the system cannot locate the SplashKit module. This documentation details the issue and the fix for it.

## Type of change

- [x] Documentation (update or new)

## Testing Checklist

- [x] Tested in latest Chrome
- [x] Tested in latest Firefox
- [x] npm run build
- [x] npm run preview

## Folders and Files Added/Modified

- Added:
  - [x] mac-issue-7.mdx
- Modified:
  - [x] index.mdx
