### PR TITLE
has_font_name_as_string-beyond-example

### DIFF
--- a/public/beyond-splashkit/code-files/graphics/0-getting-started-with-graphics/has_font_name_as_string-beyond-example.cpp
+++ b/public/beyond-splashkit/code-files/graphics/0-getting-started-with-graphics/has_font_name_as_string-beyond-example.cpp
@@ -1,0 +1,43 @@
+#include <iostream>
+#include <SDL2/SDL.h>
+#include <SDL2/SDL_ttf.h>
+#include <SDL2/SDL_main.h>
+
+
+// Function to check if a font can be loaded
+bool has_font(const std::string &font_path)
+{
+    TTF_Font *font = TTF_OpenFont(font_path.c_str(), 16);
+    if (font)
+    {
+        TTF_CloseFont(font);
+        return true;
+    }
+    return false;
+}
+
+int main(int argc, char *argv[])
+
+{
+    // Initialize SDL2 and SDL_ttf
+    if (SDL_Init(SDL_INIT_VIDEO) < 0 || TTF_Init() < 0)
+    {
+        std::cerr << "Failed to initialize SDL2 or SDL_ttf: " << TTF_GetError() << std::endl;
+        return 1;
+    }
+
+    std::string font_path = "arial.ttf"; // Ensure the font file is present in the same directory
+    if (has_font(font_path))
+    {
+        std::cout << "Font found!" << std::endl;
+    }
+    else
+    {
+        std::cout << "Font not found!" << std::endl;
+    }
+
+    // Clean up and quit
+    TTF_Quit();
+    SDL_Quit();
+    return 0;
+}


### PR DESCRIPTION
# Description

This change adds a new C++ SDL2/SDL_ttf usage example that demonstrates how to check if a font can be successfully loaded using TTF_OpenFont. The program attempts to load arial.ttf from the local directory and prints whether the font was found. This usage example can help developers verify font availability in SDL-based projects and serves as a minimal diagnostic tool for font-related issues.

Dependencies:
SDL2
SDL_ttf
The arial.ttf file must be present in the execution directory.


## Type of change

_Please delete options that are not relevant._

- [ ] New feature (non-breaking change which adds functionality)


## How Has This Been Tested?

This example has been tested by compiling and running the program with and without the presence of the arial.ttf file in the same directory. The output correctly reflects the presence or absence of the font, displaying either “Font found!” or “Font not found!” in the terminal.

To reproduce:
1. Ensure SDL2 and SDL_ttf are installed and linked correctly.
2. Place arial.ttf in the executable directory.
3. Build the program using a C++ compiler with SDL2/SDL_ttf support.
4. Run the program and observe the output.

## Testing Checklist

- [ ] Tested in latest Chrome
- [ ] Tested in latest Firefox
- [ ] npm run build
- [ ] npm run preview

## Checklist

_Please delete options that are not relevant._

### If involving code

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings


## Folders and Files Added/Modified
- Added:
  - [ ]  beyond-splashkit/code-files/graphics/has_font_name_as_string-beyond-example.cpp
 
## Additional Notes
This example is useful as a minimal SDL font-loading check and could be included in the documentation or as a diagnostic tool for users working with fonts in SDL/SDL_ttf projects. It helps ensure developers confirm font availability at runtime and avoid crashes or silent rendering issues due to missing fonts.
