### PR TITLE
add brief OS info on istallation page cards

### DIFF
--- a/src/content/docs/installation/index.mdx
+++ b/src/content/docs/installation/index.mdx
@@ -19,7 +19,7 @@ Most of these guides also include an automated script for an easier installation
 
 <CardGrid>
   <Card title="Windows" icon="seti:windows">
-    {/* TODO: Add short text about Windows here */}
+    Windows is a widely used operating system for everyday computing tasks. MSYS2 offers a Unix-like terminal and build environment for Windows, allowing developers to compile and run native programs using Linux-style tools. WSL (Windows Subsystem for Linux) runs a Linux environment within Windows, providing access to Linux tools without virtual machines or dual booting.
     <LinkCard
       title="Installation Guide (MSYS2)"
       href="/installation/windows-msys2/"
@@ -30,21 +30,21 @@ Most of these guides also include an automated script for an easier installation
     />
   </Card>
   <Card title="MacOS" icon="apple">
-    {/* TODO: Add short text about MacOS here */}
+    macOS is a Unix-based operating system for Mac computers that provides core system functions, security features, and a graphical user interface. Developers working in mac environments use Xcode Command Line Tools which is a package that provides compilers and Unix developer tools accessible from the terminal for building software on macOS.
     <LinkCard
       title="Installation Guide"
       href="/installation/macos/"
     />
   </Card>
   <Card title="Linux" icon="linux">
-    {/* TODO: Add short text about Linux here */}
+    Linux is an open-source operating system which is widely used by those who value strong security and control over their computing environments. It offers a highly customisable platform with a wide range of distributions tailored to different needs, making it popular among developers, system administrators, and technical users for both personal and enterprise use.
     <LinkCard
       title="Installation Guide"
       href="/installation/linux/"
     />
   </Card>
   <Card title="Virtual Machine" icon="cloud-download">
-    {/* TODO: Add short text about VMs here */}
+    A Virtual Machine allows you to run a complete operating system within your existing one, providing a controlled and isolated environment. This enables users to test software, run different operating systems, or create safe sandboxes without affecting the host system.
     <LinkCard
       title="Installation Guide"
       href="/installation/virtual-machine/"


### PR DESCRIPTION
# Description

Completed TODO comments in splashkit.io-starlight/src/content/docs/installation/index.mdx noting to add some introductory information to each of the cards on the page (Windows, macOS, Linux, VM).

## Type of change

_Please delete options that are not relevant._

- [x] Documentation (update or new)

## How Has This Been Tested?

Viewed Installation page in Firefox and Chrome to review added text.

## Testing Checklist

- [x] Tested in latest Chrome
- [x] Tested in latest Firefox
- [x] npm run build
- [x] npm run preview


## Folders and Files Added/Modified

- Modified:
  - [x] file - - splashkit.io-starlight/src/content/docs/installation/index.mdx
 
## Additional Notes
