### PR TITLE
Add platform descriptions to installation overview cards

### DIFF
--- a/src/content/docs/installation/index.mdx
+++ b/src/content/docs/installation/index.mdx
@@ -19,7 +19,7 @@ Most of these guides also include an automated script for an easier installation
 
 <CardGrid>
   <Card title="Windows" icon="seti:windows">
-    {/* TODO: Add short text about Windows here */}
+    Set up SplashKit on Windows using either MSYS2 or WSL, depending on the setup that suits you.
     <LinkCard
       title="Installation Guide (MSYS2)"
       href="/installation/windows-msys2/"
@@ -30,21 +30,21 @@ Most of these guides also include an automated script for an easier installation
     />
   </Card>
   <Card title="MacOS" icon="apple">
-    {/* TODO: Add short text about MacOS here */}
+    Follow a step-by-step guide to install SplashKit on macOS and get your development environment ready.
     <LinkCard
       title="Installation Guide"
       href="/installation/macos/"
     />
   </Card>
   <Card title="Linux" icon="linux">
-    {/* TODO: Add short text about Linux here */}
+    Follow a step-by-step guide to install SplashKit on Linux and set up the tools needed to start building.
     <LinkCard
       title="Installation Guide"
       href="/installation/linux/"
     />
   </Card>
   <Card title="Virtual Machine" icon="cloud-download">
-    {/* TODO: Add short text about VMs here */}
+    Use a pre-configured virtual machine if you need an alternative way to run SplashKit on your device.
     <LinkCard
       title="Installation Guide"
       href="/installation/virtual-machine/"


### PR DESCRIPTION
# Description

This PR replaces the TODO comments in the Installation Overview page with short descriptions for the Windows, macOS, Linux, and Virtual Machine cards.

The goal is to make the page more helpful for beginners choosing an installation path.

## Type of change

- [x] Documentation (update or new)

## How Has This Been Tested?

I tested the changes locally using `npm run dev` and I checked the Installation Overview page in the browser to confirm that the updated card descriptions display correctly.

## Testing Checklist

- [x] Tested in latest Chrome
- [ ] npm run build
- [ ] Tested in latest Firefox
- [ ] npm run preview

## Checklist

_Please delete options that are not relevant._

### If involving code

- [x] I have performed a self-review of my own code

### If modified config files

- [ ] I have checked the following files for changes:
  - [ ] package.json
  - [ ] astro.config.mjs
  - [ ] netlify.toml
  - [ ] docker-compose.yml
  - [ ] custom.css

## Folders and Files Added/Modified

- Modified:

  - [x] src/content/docs/installation/index.mdx

## Additional Notes

This is a small documentation improvement focused on clarity and beginner usability.
