### PR TITLE
fix: typo separately in interfaces guide

### DIFF
--- a/src/content/docs/guides/interface/getting-started-with-interfaces.mdx
+++ b/src/content/docs/guides/interface/getting-started-with-interfaces.mdx
@@ -477,7 +477,7 @@ if button_at_position("Write To Terminal!", rectangle_from(300, 260, 200, 24)):
 </TabItem>
 </Tabs>
 
-Note how rather than _creating_ the button, and then checking if it's been clicked seperately, we've used a _single_ call to [Button](/api/interface/#button), that both shows the button _and_ returns whether its been clicked.
+Note how rather than _creating_ the button, and then checking if it's been clicked separately, we've used a _single_ call to [Button](/api/interface/#button), that both shows the button _and_ returns whether its been clicked.
 
 Now when we click on the button, our text gets printed in the terminal! You can of course put whatever code you want - for instance, the button could start your game, add an item to your stock program, or pop up extra info.
 ![Clicking the button - on click, the text 'The button was clicked!' is printed in the terminal](/gifs/guides/interface/clicking_button_write_terminal.gif)


### PR DESCRIPTION
# Description

Fixed a typo in the getting started with interfaces guide. The word "seperately" was misspelled and has been corrected to "separately".


_Please include a summary of the changes and the related issue. Please also include relevant
motivation and context. List any dependencies that are required for this change._

i have updated the type in src/content/docs/guides/interface/getting-started-with-interfaces.mdx

## Type of change

_Please delete options that are not relevant._

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
      expected)
- [x] Documentation (update or new)

## How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide instructions so we can
reproduce. Please also list any relevant details for your test configuration._

Visually reviewed the change in the file. No functional changes were made only a single word spelling correction in a markdown file.

## Testing Checklist

- [x] Tested in latest Chrome
- [ ] Tested in latest Firefox
- [x] npm run build
- [ ] npm run preview

## Folders and Files Added/Modified

- Modified:
  - [x] src/content/docs/guides/interface/getting-started-with-interfaces.mdx

## Additional Notes

Single typo fix: seperately → separately on line 480 of the interfaces guide.