### PR TITLE
fix: make check-links script cross-platform

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "setup": "node ./scripts/json-files-script.cjs && node ./scripts/usage-example-scraping.cjs && node ./scripts/api-pages-script.cjs",
     "generate-mdx": "node ./scripts/api-pages-script.cjs",
     "generate-json": "node ./scripts/json-files-script.cjs && node ./scripts/usage-example-scraping.cjs",
-    "check-links": "SET CHECK_LINKS=true && npm run build && SET CHECK_LINKS=false"
+    "check-links": "node -e \"const { spawnSync } = require('node:child_process'); const cmd = process.platform === 'win32' ? 'npm.cmd' : 'npm'; const result = spawnSync(cmd, ['run', 'build'], { stdio: 'inherit', env: { ...process.env, CHECK_LINKS: 'true' } }); process.exit(result.status ?? 1);\""
   },
   "dependencies": {
     "@astrojs/react": "^4.2.7",


### PR DESCRIPTION
# Description

This PR fixes 'npm run check-links' so it actually works on Mac, Linux, and the dev container

The script was using 'SET' to define an environment variable, which is Windows-only. On Unix-like systems it just fails immediately with 'SET: not found', the build never even starts.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

I tested this by running:

`npm run check-links`

After the fix, the script runs correctly and reaches the link-validation stage of the build. The remaining failure is from existing invalid hash links like '/api/geometry/#rectangle-around', not from the 'check-links' script itself.

## Checklist

### If involving code

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

### If modified config files

- [x] I have checked the following files for changes:
  - [x] package.json

## Folders and Files Added/Modified

- Modified:
  - [x] package.json
  
## Additional Notes

This PR is intentionally limited to `package.json` so the cross-platform script fix stays separate from the repository’s existing build and link validation issues.