### PR TITLE
Add Current Window Has Border / Current Window Toggle Border  usage example

### DIFF
--- a/public/usage-examples/windows/current_window_toggle_border-1-example-oop.cs
+++ b/public/usage-examples/windows/current_window_toggle_border-1-example-oop.cs
@@ -1,0 +1,33 @@
+using SplashKitSDK;
+
+namespace CurrentWindowToggleBorderExample
+{
+    public class Program
+    {
+        public static void Main()
+        {
+            SplashKit.OpenWindow("Press B to Toggle Border", 700, 250);
+
+            while (!SplashKit.QuitRequested())
+            {
+                SplashKit.ProcessEvents();
+
+                if (SplashKit.KeyTyped(KeyCode.BKey))
+                {
+                    SplashKit.CurrentWindowToggleBorder();
+                }
+
+                string borderState = SplashKit.CurrentWindowHasBorder() ? "On" : "Off";
+
+                SplashKit.ClearScreen(Color.White);
+
+                SplashKit.DrawText("Press B to toggle border", Color.Black, 20, 20);
+                SplashKit.DrawText("Border: " + borderState, Color.Blue, 20, 80);
+
+                SplashKit.RefreshScreen(60);
+            }
+
+            SplashKit.CloseAllWindows();
+        }
+    }
+}

--- a/public/usage-examples/windows/current_window_toggle_border-1-example-top-level.cs
+++ b/public/usage-examples/windows/current_window_toggle_border-1-example-top-level.cs
@@ -1,0 +1,25 @@
+using SplashKitSDK;
+using static SplashKitSDK.SplashKit;
+
+OpenWindow("Press B to Toggle Border", 700, 250);
+
+while (!QuitRequested())
+{
+    ProcessEvents();
+
+    if (KeyTyped(KeyCode.BKey))
+    {
+        CurrentWindowToggleBorder();
+    }
+
+    string borderState = CurrentWindowHasBorder() ? "On" : "Off";
+
+    ClearScreen(ColorWhite());
+
+    DrawText("Press B to toggle border", ColorBlack(), 20, 20);
+    DrawText($"Border: {borderState}", ColorBlue(), 20, 80);
+
+    RefreshScreen(60);
+}
+
+CloseAllWindows();

--- a/public/usage-examples/windows/current_window_toggle_border-1-example.cpp
+++ b/public/usage-examples/windows/current_window_toggle_border-1-example.cpp
@@ -1,0 +1,32 @@
+#include "splashkit.h"
+#include <string>
+
+using namespace std;
+
+int main()
+{
+    open_window("Press B to Toggle Border", 700, 250);
+
+    while (!quit_requested())
+    {
+        process_events();
+
+        if (key_typed(B_KEY))
+        {
+            current_window_toggle_border();
+        }
+
+        bool has_border = current_window_has_border();
+        string border_state = has_border ? "On" : "Off";
+
+        clear_screen(COLOR_WHITE);
+
+        draw_text("Press B to toggle border", COLOR_BLACK, 20, 20);
+        draw_text("Border: " + border_state, COLOR_BLUE, 20, 80);
+
+        refresh_screen(60);
+    }
+
+    close_all_windows();
+    return 0;
+}

--- a/public/usage-examples/windows/current_window_toggle_border-1-example.py
+++ b/public/usage-examples/windows/current_window_toggle_border-1-example.py
@@ -1,0 +1,20 @@
+from splashkit import *
+
+open_window("Press B to Toggle Border", 700, 250)
+
+while not quit_requested():
+    process_events()
+
+    if key_typed(KeyCode.b_key):
+        current_window_toggle_border()
+
+    border_state = "On" if current_window_has_border() else "Off"
+
+    clear_screen(color_white())
+
+    draw_text_no_font_no_size("Press B to toggle border", color_black(), 20, 20)
+    draw_text_no_font_no_size(f"Border: {border_state}", color_blue(), 20, 80)
+
+    refresh_screen()
+
+close_all_windows()

--- a/public/usage-examples/windows/current_window_toggle_border-1-example.txt
+++ b/public/usage-examples/windows/current_window_toggle_border-1-example.txt
@@ -1,0 +1,3 @@
+Press B to Toggle Border
+
+Press B to toggle the current window border and display the current border state.


### PR DESCRIPTION
## Summary
This pull request adds an interactive border-related usage example in the windows category.

## Functions demonstrated
- current_window_toggle_border
- current_window_has_border

## What the example does
This example opens a window, allows the user to press `B` to toggle the border on and off, and displays the current border state on screen.

## Why both functions are used together
The goal of this example is to demonstrate border interaction clearly for learners.  
`current_window_toggle_border` performs the toggle action, while `current_window_has_border` is used to check and display the current border state so that the result of the interaction is easier to understand.

## Files added
- current_window_toggle_border-1-example.cpp
- current_window_toggle_border-1-example.py
- current_window_toggle_border-1-example-top-level.cs
- current_window_toggle_border-1-example-oop.cs
- current_window_toggle_border-1-example.txt
- current_window_toggle_border-1-example.gif

## Testing
Tested by running:
- C++ version
- Python version

Verified that:
- the window opens correctly
- pressing `B` toggles the window border
- the displayed border state updates correctly

## Notes
This PR is intended as a small interactive border behaviour example rather than a strictly isolated single-function example.
<img width="1108" height="1076" alt="image" src="https://github.com/user-attachments/assets/ae06a282-33a1-41ab-992c-646c75176354" />

